### PR TITLE
Fix import error in paperspace training script

### DIFF
--- a/experiments/02_compositional_language/paperspace_train_with_safeguards.py
+++ b/experiments/02_compositional_language/paperspace_train_with_safeguards.py
@@ -142,7 +142,8 @@ def train_with_safeguards(storage_dir):
     print("="*60)
     
     # Import the minimal training (most reliable)
-    from train_progressive_minimal import create_model, create_dataset, SCANTokenizer
+    from models import create_model
+    from train_progressive_curriculum import create_dataset, SCANTokenizer
     from scan_data_loader import SCANDataLoader
     from modification_generator import ModificationGenerator
     
@@ -302,7 +303,8 @@ def comprehensive_evaluation(storage_dir):
     print("STEP 3: Comprehensive Evaluation")
     print("="*60)
     
-    from train_progressive_minimal import create_model, create_dataset, SCANTokenizer
+    from models import create_model
+    from train_progressive_curriculum import create_dataset, SCANTokenizer
     from scan_data_loader import SCANDataLoader
     
     # Load everything


### PR DESCRIPTION
## Summary
Fixes ImportError when running `paperspace_train_with_safeguards.py` on Paperspace.

## Issue
The script was trying to import functions from `train_progressive_minimal` that don't exist there.

## Fix
Updated imports to use the correct modules:
- `create_model` → imported from `models.py`
- `create_dataset`, `SCANTokenizer` → imported from `train_progressive_curriculum.py`

## Testing
The imports now point to functions that exist in their respective files.

This fix allows the training script to run properly on Paperspace.

🤖 Generated with Claude Code